### PR TITLE
`dateMode` tests

### DIFF
--- a/src/components/date_picker/super_date_picker/date_modes.test.js
+++ b/src/components/date_picker/super_date_picker/date_modes.test.js
@@ -1,30 +1,48 @@
 import { getDateMode, toAbsoluteString, toRelativeString } from './date_modes';
 
-jest.mock('@elastic/datemath', () => ({
-  parse: () => ({ toISOString: () => 'gsoc' }),
-}));
-
-jest.mock('./relative_utils', () => ({
-  parseRelativeParts: () => 'in eui',
-  toRelativeStringFromParts: () => 'now',
-}));
+jest.mock('@elastic/datemath', () => {
+  const moment = jest.requireActual('moment');
+  const datemath = jest.requireActual('@elastic/datemath');
+  const anchor = '2019-03-19T05:25:00.000Z';
+  const anchoredDate = new Date(Date.parse(anchor));
+  // https://momentjs.com/docs/#/customization/now/
+  const offset = anchoredDate.getTime() - Date.now();
+  moment.now = () => offset + Date.now();
+  return {
+    ...datemath,
+    parse: (text, options) =>
+      datemath.parse(text, {
+        forceNow: anchoredDate, // For `toAbsoluteString`
+        momentInstance: moment, // For `toRelativeString`
+        ...options,
+      }),
+  };
+});
 
 describe('dateMode', () => {
-  test('date mode', () => {
+  test('getDateMode', () => {
     expect(getDateMode('now')).toBe('now');
-    expect(getDateMode('acknowledge')).toBe('relative');
-    expect(getDateMode('eui')).toBe('absolute');
+    expect(getDateMode('now/1d')).toBe('relative');
+    expect(getDateMode('2020-03-19T05:25:00.000Z')).toBe('absolute');
   });
 
-  test('absolute string', () => {
-    expect(toAbsoluteString('now&1d', true)).toBe('gsoc');
-    expect(toAbsoluteString('now/0.5y', false)).toBe('gsoc');
-    expect(toAbsoluteString('now-1w/w')).toBe('gsoc');
+  test('toAbsoluteString', () => {
+    expect(toAbsoluteString('now')).toBe('2019-03-19T05:25:00.000Z');
+    expect(toAbsoluteString('now/1d')).toBe('2019-03-19T05:00:00.000Z');
+    expect(toAbsoluteString('now/1d', true)).toBe('2019-03-20T04:59:59.999Z');
+    expect(toAbsoluteString('now+y')).toBe('2020-03-19T05:25:00.000Z');
+    expect(toAbsoluteString('now+y', true)).toBe('2020-03-19T05:25:00.000Z');
+    expect(toAbsoluteString('now-1w')).toBe('2019-03-12T05:25:00.000Z');
+    expect(toAbsoluteString('now-1w', true)).toBe('2019-03-12T05:25:00.000Z');
+    expect(toAbsoluteString('now-1w/w')).toBe('2019-03-10T06:00:00.000Z');
+    expect(toAbsoluteString('now-1w/w', true)).toBe('2019-03-17T04:59:59.999Z');
   });
 
-  test('relative string', () => {
-    expect(toRelativeString('now&1d')).toBe('now');
-    expect(toRelativeString('now/0.5y')).toBe('now');
-    expect(toRelativeString('now-1w/w')).toBe('now');
+  test('toRelativeString', () => {
+    expect(toRelativeString('2019-03-19T05:25:00.000Z')).toBe('now');
+    expect(toRelativeString('2020-03-19T05:25:00.000Z')).toBe('now+1y');
+    expect(toRelativeString('2019-03-12T05:25:00.000Z')).toBe('now-1w');
+    expect(toRelativeString('2019-03-17T04:59:59.999Z')).toBe('now-2d');
+    expect(toRelativeString('2018-04-15T00:00:00.000Z')).toBe('now-11M');
   });
 });


### PR DESCRIPTION
This mocks `@elastic/datemath` `parse` with a static date reference so we can get accurate relative and absolute times regardless of the when the test are ran.