### PR TITLE
Improving text and example

### DIFF
--- a/src-docs/src/views/code/code_block_pre.js
+++ b/src-docs/src/views/code/code_block_pre.js
@@ -20,9 +20,10 @@ export default () => (
             paddingSize="m"
             color="dark"
             overflowHeight={300}
+            whiteSpace="pre"
             isCopyable>
               <div>
-                When the whiteSpace property is set to pre all the whitespaces will be kept as is and the text only wraps when line breaks are in the content.
+                In this example, the whiteSpace property is set to pre. All the whitespaces will be kept as is and the text only wraps when line breaks are in the content.
               </div>
             </EuiCodeBlock>
 

--- a/src-docs/src/views/code/code_example.js
+++ b/src-docs/src/views/code/code_example.js
@@ -72,7 +72,7 @@ export const CodeExample = {
       demo: <CodeBlock />,
     },
     {
-      title: 'CodeBlock with pre white space',
+      title: 'CodeBlock and white-space',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -85,8 +85,11 @@ export const CodeExample = {
       ],
       text: (
         <p>
-          <EuiCode>EuiCodeBlock</EuiCode> allows whiteSpace property to be set
-          allowing user to breaks/white space forcefuly or not.
+          By default, the <EuiCode>whiteSpace</EuiCode> property is set to{' '}
+          <EuiCode>pre-wrap</EuiCode>. This makes the text wrap when needed. You
+          can, however, pass <EuiCode>pre</EuiCode> to the{' '}
+          <EuiCode>whiteSpace</EuiCode> prop and the text won&apos;t wrap unless
+          line breaks are in the content.
         </p>
       ),
       props: { EuiCodeBlockImpl },


### PR DESCRIPTION
Hi @anishagg17,

This is going to be my final PR. 🙂 

The `src-docs/src/views/code/code_block_pre.js` example was missing a `whiteSpace="pre"`. I also improved the text. 
